### PR TITLE
Test ubuntues without the universe repo enabled

### DIFF
--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -42,7 +42,7 @@ main() {
 
   start_container
 
-  [[ -e ${requirements} ]] &&run_galaxy_install
+  [[ -e ${requirements} ]] && run_galaxy_install
   run_syntax_check
   run_test_playbook
   run_idempotence_test

--- a/test.yml
+++ b/test.yml
@@ -4,6 +4,25 @@
 - hosts: all
   gather_facts: true
   become: true
+
+  # Remove "universe" repository to check if the role properly re-enables it
+  pre_tasks:
+    - name: 'Install software-properties-common'
+      command: 'apt-get install -y software-properties-common'
+      changed_when: false
+
+    - name: 'Ensure universe repository is not enabled/defined'
+      command: 'add-apt-repository -r universe'
+      changed_when: false
+
+    - name: 'Remove software-properties-common, as the role will do that, which should also be tested'
+      command: 'apt-get purge -y software-properties-common'
+      changed_when: false
+
+    - name: 'Update repositories metadata'
+      command: 'apt-get update'
+      changed_when: false
+
   roles:
     - role: role_under_test
 


### PR DESCRIPTION
In order to ensure that the role adds it properly

I only tested the same commands manually in a vanilla ubuntu:xenial docker image

Test for https://github.com/open-io/ansible-role-openio-repository/issues/21