### PR TITLE
Remove misplaced CI image preparation tasks

### DIFF
--- a/test.yml
+++ b/test.yml
@@ -5,28 +5,6 @@
   gather_facts: true
   become: true
 
-  # Remove "universe" repository to check if the role properly re-enables it
-  pre_tasks:
-    - name: 'Install software-properties-common'
-      command: 'apt-get install -y software-properties-common'
-      changed_when: false
-      when: ansible_distribution == 'Ubuntu'
-
-    - name: 'Ensure universe repository is not enabled/defined'
-      command: 'add-apt-repository -r universe'
-      changed_when: false
-      when: ansible_distribution == 'Ubuntu'
-
-    - name: 'Remove software-properties-common, as the role will do that, which should also be tested'
-      command: 'apt-get purge -y software-properties-common'
-      changed_when: false
-      when: ansible_distribution == 'Ubuntu'
-
-    - name: 'Update repositories metadata'
-      command: 'apt-get update'
-      changed_when: false
-      when: ansible_distribution == 'Ubuntu'
-
   roles:
     - role: role_under_test
 


### PR DESCRIPTION
They break idempotency test and the docker image has been modified to
not have the "universe" repo.

Locally CI tested: ubuntu:xenial, centos:7 & debian:9, all passed