### PR TITLE
BUGFIX(repository): Exclude EPEL's netdata version for CentOS this time

### DIFF
--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -49,12 +49,12 @@
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
 
-- name: "Exclude zeromq from EPEL to avoid conflicts with the Openstack repository"
+- name: "Package exclusions from EPEL to avoid conflicts with other repositories (OpenStack, OpenIO)"
   ini_file:
     dest: /etc/yum.repos.d/epel.repo
     section: epel
     option: exclude
-    value: zeromq
+    value: zeromq netdata
 
 - name: "Configure Openstack {{ openio_repository_openstack_release }} release repository"
   package:


### PR DESCRIPTION
 ##### SUMMARY
We must use our own repackaged netdata, so disallow newer ones coming
from EPEL

 ##### ISSUE TYPE
- Bugfix Pull Request

 ##### SCOPE (skeleton only)
- SDS

 ##### IMPACT

 ##### ADDITIONAL INFORMATION
The 18.10 SDS deployment has been broken by the new netdata-1.13.0-2.el7
that appeared on EPEL repository.

See:
https://lists.fedoraproject.org/archives/list/epel-package-announce@lists.fedoraproject.org/message/WTN2EPKPYCDYGMGXT2U2HTHENJIFRNQP/