### PR TITLE
BUGFIX/MAJOR(repositorie): Remove exclusion of zeromq from EPEL

### DIFF
--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -54,7 +54,7 @@
     dest: /etc/yum.repos.d/epel.repo
     section: epel
     option: exclude
-    value: zeromq netdata
+    value: netdata
 
 - name: "Configure Openstack {{ openio_repository_openstack_release }} release repository"
   package:

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -61,7 +61,7 @@
     dest: /etc/yum.repos.d/epel.repo
     section: epel
     option: exclude
-    value: zeromq netdata
+    value: netdata
 
 - name: "Configure Openstack {{ openio_repository_openstack_release }} release repository"
   package:


### PR DESCRIPTION
 ##### SUMMARY

Currently, the installation is broken.
```
failed: [node1] (item=openio-sds-server) => changed=false
  attempts: 5
  msg: |-
    Error: Package: python2-zmq-14.7.0-8.el7.x86_64 (epel)
               Requires: libzmq.so.5()(64bit)
```

The new package changes the dependency
https://github.com/open-io/rpm-specfiles/pull/198

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION