### PR TITLE
BUGFIX/MINOR(repository): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -9,17 +9,20 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: "Configure EPEL repository"
   package:
     name: "epel-release"
     state: present
   when: openio_repository_manage_epel_repository
+  tags: install
 
 - name: "Setup the repository key"
   rpm_key:
     state: present
     key: "{{ openio_repository_mirror_url_base_nocreds }}/{{ openio_repository_gpgkey }}"
+  tags: install
 
 - name: "Configure repositories for {{ ansible_distribution}} {{ ansible_distribution_major_version }}"
   yum_repository:
@@ -34,6 +37,7 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: "Configure source repositories for {{ ansible_distribution}} {{ ansible_distribution_major_version }}"
   yum_repository:
@@ -48,6 +52,7 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: "Package exclusions from EPEL to avoid conflicts with other repositories (OpenStack, OpenIO)"
   ini_file:
@@ -55,11 +60,12 @@
     section: epel
     option: exclude
     value: netdata
+  tags: install
 
 - name: "Configure Openstack {{ openio_repository_openstack_release }} release repository"
   package:
     name: "centos-release-openstack-{{ openio_repository_openstack_release }}"
     state: present
   when: openio_repository_manage_openstack_repository
-
+  tags: install
 ...

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -9,24 +9,28 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: Install python-apt
   package:
     name: python-apt
     state: present
   check_mode: false
+  tags: install
 
 - name: Ensure lsb-release package is installed
   package:
     name: "lsb-release"
     state: present
   register: lsbrelease
+  tags: install
 
 - name: "Refetch facts"
   setup:
     gather_subset: min
     filter: ansible_lsb
   when: lsbrelease.changed
+  tags: install
 
 - name: "Configure Backports repository for {{ ansible_lsb.id }} {{ ansible_distribution_release }}"
   apt_repository:
@@ -34,12 +38,14 @@
     state: present
     filename: "{{ ansible_distribution_release }}-backports"
   when: ansible_lsb.id == 'Debian'
+  tags: install
 
 - name: "Setup repository key"
   apt_key:
     id: "{{ openio_repository_keyid }}"
     url: "{{ openio_repository_mirror_url_base_nocreds }}/{{ openio_repository_gpgkey }}"
     state: present
+  tags: install
 
 - name: "Configure repositories for {{ ansible_lsb.id }} {{ ansible_distribution_release }}"
   apt_repository:
@@ -50,11 +56,13 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: "Update APT cache"
   apt:
     update_cache: true
   changed_when: false
+  tags: install
 
 - name: Configure policy to disable starting services at package install
   copy:
@@ -65,5 +73,6 @@
     mode: 0755
   when:
     - openio_repository_disable_policy_autostart
+  tags: install
 
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -9,12 +9,14 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: "Configure EPEL repository"
   package:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
   when: openio_repository_manage_epel_repository
+  tags: install
 
 - name: Import EPEL GPG key.
   rpm_key:
@@ -22,11 +24,13 @@
     state: present
   when: openio_repository_manage_epel_repository
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: install
 
 - name: "Setup the repository key"
   rpm_key:
     state: present
     key: "{{ openio_repository_mirror_url_base_nocreds }}/{{ openio_repository_gpgkey }}"
+  tags: install
 
 - name: "Configure repositories for {{ ansible_distribution}} {{ ansible_distribution_major_version }}"
   yum_repository:
@@ -41,6 +45,7 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: "Configure source repositories for {{ ansible_distribution}} {{ ansible_distribution_major_version }}"
   yum_repository:
@@ -55,6 +60,7 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: "Package exclusions from EPEL to avoid conflicts with other repositories (OpenStack, OpenIO)"
   ini_file:
@@ -62,11 +68,12 @@
     section: epel
     option: exclude
     value: netdata
+  tags: install
 
 - name: "Configure Openstack {{ openio_repository_openstack_release }} release repository"
   package:
     name: "http://repos.fedorapeople.org/repos/openstack/openstack-{{ openio_repository_openstack_release }}/rdo-release-{{ openio_repository_openstack_release }}-1.noarch.rpm"
     state: present
   when: openio_repository_manage_openstack_repository
-
+  tags: install
 ...

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -9,18 +9,21 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: Install python-apt
   package:
     name: python-apt
     state: present
   check_mode: false
+  tags: install
 
 - name: "Setup repository key"
   apt_key:
     id: "{{ openio_repository_keyid }}"
     url: "{{ openio_repository_mirror_url_base_nocreds }}/{{ openio_repository_gpgkey }}"
     state: present
+  tags: install
 
 - name: "Configure repositories for {{ ansible_lsb.id }} {{ ansible_distribution_release }}"
   apt_repository:
@@ -31,21 +34,25 @@
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'
+  tags: install
 
 - name: "Install required packages to run add-apt-repository"
   package:
     name: "software-properties-common"
     state: present
+  tags: install
 
 - name: "Configure `universe` repositories for {{ ansible_lsb.id }} {{ ansible_distribution_release }}, required for python-software-properties"
   command: 'add-apt-repository universe'
   register: res
   changed_when: "' distribution component enabled for all sources.' in res.stdout"
+  tags: install
 
 - name: "Update APT cache"
   apt:
     update_cache: true
   changed_when: false
+  tags: install
 
 - name: "Install required packages to configure repositories"
   package:
@@ -57,6 +64,7 @@
     - python3-software-properties
   loop_control:
     loop_var: pkg
+  tags: install
 
 - name: "Install required packages to configure repositories"
   package:
@@ -67,7 +75,7 @@
     - software-properties-common
   loop_control:
     loop_var: pkg
-
+  tags: install
 
 - name: "Configure OpenStack {{ openio_repository_openstack_release }} release repository"
   apt_repository:
@@ -77,6 +85,7 @@
   when:
     - openio_repository_manage_openstack_repository
     - ansible_distribution_release == 'xenial'
+  tags: install
 
 - name: "Setup repository key for OpenStack repository"
   apt_key:
@@ -85,11 +94,13 @@
   when:
     - openio_repository_manage_openstack_repository
     - ansible_distribution_release == 'xenial'
+  tags: install
 
 - name: "Update APT cache"
   apt:
     update_cache: true
   changed_when: false
+  tags: install
 
 - name: Configure policy to disable starting services at package install
   copy:
@@ -100,5 +111,5 @@
     mode: 0755
   when:
     - openio_repository_disable_policy_autostart
-
+  tags: install
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,13 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
+  tags:
+    - install
+    - configure
 
 - name: "Include {{ ansible_distribution }} tasks"
   include_tasks: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-
 ...


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION