### PR TITLE
BUMP(repository): CI - Set requirements.yml to `19.10`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 openio_repository_products:
   sds:
-    release: "{{ openio_sds_release | d('19.04') }}"
+    release: "{{ openio_sds_release | d('19.10') }}"
 #  oiofs:
 #    release: 'unstable'
 #    user: 'oiofs'

--- a/docker-tests/checks.bats
+++ b/docker-tests/checks.bats
@@ -10,24 +10,24 @@
     echo "output: "$output
     echo "status: "$status
     [[ "${status}" -eq "0" ]]
-    [[ "${output}" =~ "/etc/yum.repos.d/openio-sds-19.04.repo /etc/yum.repos.d/openio-test-19.04.repo" ]]
+    [[ "${output}" =~ "/etc/yum.repos.d/openio-sds-19.10.repo /etc/yum.repos.d/openio-test-19.10.repo" ]]
   elif [ "${DISTRIBUTION}" == "ubuntu" ]; then
     run docker exec -ti ${SUT_ID} bash -c 'ls /etc/apt/sources.list.d/openio* | tr "\n" " "'
     echo "output: "$output
     echo "status: "$status
     [[ "${status}" -eq "0" ]]
-    [[ "${output}" =~ "/etc/apt/sources.list.d/openio-sds-19.04.list /etc/apt/sources.list.d/openio-test-19.04.list" ]]
+    [[ "${output}" =~ "/etc/apt/sources.list.d/openio-sds-19.10.list /etc/apt/sources.list.d/openio-test-19.10.list" ]]
   fi
 }
 
 @test 'Check install package' {
   if [ "${DISTRIBUTION}" == "centos" ]; then
-    run docker exec -ti ${SUT_ID} bash -c 'yum install --disablerepo="*" --enablerepo="openio-sds-19.04,base" -y openio-gridinit'
+    run docker exec -ti ${SUT_ID} bash -c 'yum install --disablerepo="*" --enablerepo="openio-sds-19.10,base" -y openio-gridinit'
     echo "output: "$output
     echo "status: "$status
     [[ "${status}" -eq "0" ]]
   elif [ "${DISTRIBUTION}" == "ubuntu" ]; then
-    run docker exec -ti ${SUT_ID} bash -c 'rm -f /etc/apt/sources.list.d/openio-test-19.04.list; apt update; apt install openio-gridinit -y'
+    run docker exec -ti ${SUT_ID} bash -c 'rm -f /etc/apt/sources.list.d/openio-test-19.10.list; apt update; apt install openio-gridinit -y'
     echo "output: "$output
     echo "status: "$status
     [[ "${status}" -eq "0" ]]

--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,5 +1,5 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-users.git
-  version: "19.04"
+  version: "19.10"
   name: users
 ...

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -15,7 +15,7 @@
       openio_repository_mirror_host: mirror2.openio.io
       openio_repository_products:
         test:
-          release: '19.04'
+          release: '19.10'
           password: 'bar'
           user: 'foo'
 


### PR DESCRIPTION
 ##### SUMMARY

In order to be able to test the roles in `19.10`, it is necessary to change the branches in this file.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION