### PR TITLE
CHANGE(repository): Remove the `netdata` exclusion

### DIFF
--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -54,14 +54,6 @@
   no_log: '{{ openio_repository_no_log }}'
   tags: install
 
-- name: "Package exclusions from EPEL to avoid conflicts with other repositories (OpenStack, OpenIO)"
-  ini_file:
-    dest: /etc/yum.repos.d/epel.repo
-    section: epel
-    option: exclude
-    value: netdata
-  tags: install
-
 - name: "Configure Openstack {{ openio_repository_openstack_release }} release repository"
   package:
     name: "centos-release-openstack-{{ openio_repository_openstack_release }}"

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -62,14 +62,6 @@
   no_log: '{{ openio_repository_no_log }}'
   tags: install
 
-- name: "Package exclusions from EPEL to avoid conflicts with other repositories (OpenStack, OpenIO)"
-  ini_file:
-    dest: /etc/yum.repos.d/epel.repo
-    section: epel
-    option: exclude
-    value: netdata
-  tags: install
-
 - name: "Configure Openstack {{ openio_repository_openstack_release }} release repository"
   package:
     name: "http://repos.fedorapeople.org/repos/openstack/openstack-{{ openio_repository_openstack_release }}/rdo-release-{{ openio_repository_openstack_release }}-1.noarch.rpm"


### PR DESCRIPTION
 ##### SUMMARY

Since we package the rpm netdata with a epoch time in its name, we doesn't need this exlusion anymore.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION