### PR TITLE
CHANGE(repository): Prepare for the new "unstable" repository handling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,17 @@ openio_repository_products:
   sds:
     release: "{{ openio_sds_release | d('19.04') }}"
 #  oiofs:
-#    release: 'unstable'
+#    release: '19.04'
 #    user: 'oiofs'
 #    password: '################'
+
+# To use "unstable" packages (without using the QA "testing" compound repository
+# Call this role two times, the first time as above to setup a stable repository
+# then a second time to setup the additional "unstable" repository, like that:
+#
+#openio_repository_products:
+#  sds:
+#    release: "{{ openio_sds_release | d('19.04') }}/unstable"
 
 openio_repository_openstack_release: "{{ openio_openstack_distro | d('queens') }}"
 openio_repository_manage_openstack_repository: true

--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -26,9 +26,9 @@
 
 - name: "Configure repositories for {{ ansible_distribution}} {{ ansible_distribution_major_version }}"
   yum_repository:
-    name: "openio-{{ repo.key }}-{{ repo.value.release }}"
+    name: "openio-{{ repo.key }}-{{ repo.value.release | replace('/', '-') }}"
     description: "OpenIO {{ repo.key }} {{ repo.value.release }} packages for Entreprise Linux $releasever - $basearch"
-    file: "openio-{{ repo.key }}-{{ repo.value.release }}"
+    file: "openio-{{ repo.key }}-{{ repo.value.release | replace('/', '-') }}"
     baseurl: "{{ openio_repository_mirror_url_base }}/{{ repo.key }}/{{ repo.value.release }}/el/$releasever/$basearch"
     state: "{{ repo.value.state | default(openio_repository_product_state_default) }}"
     enabled: "yes"
@@ -39,7 +39,8 @@
   no_log: '{{ openio_repository_no_log }}'
   tags: install
 
-- name: "Configure source repositories for {{ ansible_distribution}} {{ ansible_distribution_major_version }}"
+# This is not setup for "unstable" releases (f.e.: '19.10/unstable', see `when` clause below)
+- name: "Configure source repositories for {{ ansible_distribution }} {{ ansible_distribution_major_version }}"
   yum_repository:
     name: "openio-{{ repo.key }}-{{ repo.value.release }}-source"
     description: "OpenIO {{ repo.key }} {{ repo.value.release }} packages for Entreprise Linux $releasever - $basearch - Source"
@@ -49,6 +50,7 @@
     enabled: "no"
     gpgcheck: "yes"
   with_dict: "{{ openio_repository_products }}"
+  when: "'/' not in repo.value.release"
   loop_control:
     loop_var: repo
   no_log: '{{ openio_repository_no_log }}'

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -29,7 +29,7 @@
   apt_repository:
     repo: "deb {{ openio_repository_mirror_url_base }}/{{ repo.key }}/{{ repo.value.release }}/{{ ansible_lsb.id | default(ansible_distribution) }}/ {{ ansible_distribution_release }}/"
     state: "{{ repo.value.state | default(openio_repository_product_state_default) }}"
-    filename: "openio-{{ repo.key }}-{{ repo.value.release }}"
+    filename: "openio-{{ repo.key }}-{{ repo.value.release | replace('/', '-') }}"
   with_dict: "{{ openio_repository_products }}"
   loop_control:
     loop_var: repo


### PR DESCRIPTION
 ##### SUMMARY
The new per-release version "unstable" repositories will be located
inside the release directory, this will help setup them.

 ##### ISSUE TYPE
- Feature Pull Request

 ##### SCOPE (skeleton only)

 ##### IMPACT
Should be harmless for "stable" repositories setup

 ##### ADDITIONAL INFORMATION
JIRA: R1910-39

The mirror directory tree looks like the following:

19.10
|-- Debian -> debian
|-- Ubuntu -> ubuntu
|-- centos -> el
|-- debian
|-- el
|   |-- 7
|   |   |-- SRPM
|   |   `-- x86_64
|   `-- 7Server -> 7
|-- ubuntu
|   |-- bionic
|   `-- xenial
`-- unstable             <==== HERE ARE THE NEW UNSTABLE REPOS
    |-- Ubuntu -> ubuntu
    |-- centos -> el
    |-- el
    |   `-- 7
    |       `-- x86_64
    `-- ubuntu
        |-- bionic
        `-- xenial

To use, first use the role to setup a stable repository as usual
since the new "unstable" repositories are not full featured, but
only contain new versions of OpenIO SDS packages and not their
dependencies. For example:

```
openio_repository_products:
  sds:
    release: "19.10"
```

Then use this role a second time, to setup the "unstable" repo,
like the following:

```
openio_repository_products:
  sds:
    release: "19.10/unstable"
```