### PR TITLE
CHANGE(repositories): move variables from `vars` to `default`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,12 @@ openio_repository_mirror_host: "{{ openio_mirror | d('mirror.openio.io') }}"
 openio_repository_no_log: "{{ openio_no_log | d(default_openio_no_log) | d(true) }}"
 openio_repository_check_reachability: true
 
+# Credentials for private repo, dependent on "with_dict" loop variable: "repo"
+# See tasks/{RedHat,Debian,Ubuntu}.yml
+openio_repository_creds: "{% if repo.value.user is defined and repo.value.password is defined %}{{ repo.value.user }}:{{ repo.value.password }}@{% endif %}"
+
+openio_repository_mirror_url_base: "http://{{ openio_repository_creds }}{{ openio_repository_mirror_host }}/pub/repo/openio"
+
+# The following is only used to get the repository signing keys
+openio_repository_mirror_url_base_nocreds: "http://{{ openio_repository_mirror_host }}/pub/repo/openio"
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,13 +1,2 @@
 ---
-# vars file for ansible-role-openio-repository
-
-# Credentials for private repo, dependent on "with_dict" loop variable: "repo"
-# See tasks/{RedHat,Debian,Ubuntu}.yml
-openio_repository_creds: "{% if repo.value.user is defined and repo.value.password is defined %}{{ repo.value.user }}:{{ repo.value.password }}@{% endif %}"
-
-openio_repository_mirror_url_base: "http://{{ openio_repository_creds }}{{ openio_repository_mirror_host }}/pub/repo/openio"
-
-# The following is only used to get the repository signing keys
-openio_repository_mirror_url_base_nocreds: "http://{{ openio_repository_mirror_host }}/pub/repo/openio"
-
 ...


### PR DESCRIPTION
 ##### SUMMARY
in `vars` should only remain variables that must be fixed.
All the others must be set in `defaults` (almost all variables).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION