### PR TITLE
CHANGE(repository): Change default of `openio_repository_no_log`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ openio_repository_manage_epel_repository: true
 openio_repository_disable_policy_autostart: true
 openio_repository_product_state_default: 'present'
 openio_repository_mirror_host: "{{ openio_mirror | d('mirror.openio.io') }}"
-openio_repository_no_log: "{{ openio_no_log | d(default_openio_no_log) | d(true) }}"
+openio_repository_no_log: "{{ openio_no_log | d(true) }}"
 openio_repository_check_reachability: true
 
 # Credentials for private repo, dependent on "with_dict" loop variable: "repo"


### PR DESCRIPTION
 ##### SUMMARY

The playbook hardcode these calls. Now the defaults are good and there is no more hardcode.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION